### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Description and Changes made
+
+<!-- Please include a summary of the changes and the related motivation -->
+
+## Related Issue
+
+<!-- If this PR addresses an issue, please link it here. Example: Closes #71 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code where necessary
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] I have added documentation wherever appropriate
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->
+
+## Additional Notes
+
+<!-- Any other information reviewers should be aware of -->


### PR DESCRIPTION
This pull request adds a standardized Pull Request template to the repository.

- The template is located at `.github/pull_request_template.md`
- It provides sections for contributors to describe their changes, list modifications, link related issues, and check compliance with contribution guidelines.
- The goal is to improve the quality and consistency of PR submissions, making review and collaboration easier for maintainers and contributors.

Please review and let me know if any adjustments are needed.

Closes #71 